### PR TITLE
fix for extension:int asc

### DIFF
--- a/index.php
+++ b/index.php
@@ -395,7 +395,7 @@ echo '	      </div>';
 // Get List Of Extensions
 $sql = "    select * from v_extensions  ";
 $sql .= "    where domain_uuid = :domain_uuid ";
-$sql .= "    order by extension::int asc ";
+$sql .= "    order by extension asc ";
 $parameters['domain_uuid'] = $_SESSION['domain_uuid'];
 $db = new database;
 $extensions = $db->select($sql, $parameters);


### PR DESCRIPTION
Fix for this case:
`ringotel/:2819 Uncaught (in promise) TypeError: extensionsPHP?.map is not a function`
`Seems to be ordering the extensions by number, all extensions on that domain are in fact numbers, however one is a long number such in this case for example 6111111111.`