### PR TITLE
Feature/dynamic app config and  email autofill

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ php /var/www/fusionpbx/core/upgrade/upgrade.php --permissions
 php /var/www/fusionpbx/core/upgrade/upgrade.php
 ```
 
+Customize the Application Display Name
+```
+sed -i "s/\$apps\[\$x\]\['name'\] = \"Ringotel\";/\$apps\[\$x\]\['name'\] = \"<Your Display Name>\";/" /var/www/fusionpbx/app/<your-folder-name>/app_config.php
+```
+
 Optional: Ringotel could be installed into a different directory such as rt.
 ```
 git clone https://github.com/fusionpbx/fusionpbx-app-ringotel.git rt

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ php /var/www/fusionpbx/core/upgrade/upgrade.php --permissions
 php /var/www/fusionpbx/core/upgrade/upgrade.php
 ```
 
-**Customize the display name** (Change `<Your Display Name>` to what you want it to be):
+**Customize the display name** (Change `<Your Display Name>` and `<your-folder-name>`to what you want it to be):
 ```
 sed -i "s/\$apps\[\$x\]\['name'\] = \"Ringotel\";/\$apps\[\$x\]\['name'\] = \"<Your Display Name>\";/" /var/www/fusionpbx/app/<your-folder-name>/app_config.php
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ php /var/www/fusionpbx/core/upgrade/upgrade.php --permissions
 php /var/www/fusionpbx/core/upgrade/upgrade.php
 ```
 
-Customize the Application Display Name (Change <Your Display Name> to what you want it to be.)
+**Customize the display name** (Change `<Your Display Name>` to what you want it to be)
 ```
 sed -i "s/\$apps\[\$x\]\['name'\] = \"Ringotel\";/\$apps\[\$x\]\['name'\] = \"<Your Display Name>\";/" /var/www/fusionpbx/app/<your-folder-name>/app_config.php
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ php /var/www/fusionpbx/core/upgrade/upgrade.php --permissions
 php /var/www/fusionpbx/core/upgrade/upgrade.php
 ```
 
-Customize the Application Display Name
+Customize the Application Display Name (Change <Your Display Name> to what you want it to be.)
 ```
 sed -i "s/\$apps\[\$x\]\['name'\] = \"Ringotel\";/\$apps\[\$x\]\['name'\] = \"<Your Display Name>\";/" /var/www/fusionpbx/app/<your-folder-name>/app_config.php
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ php /var/www/fusionpbx/core/upgrade/upgrade.php --permissions
 php /var/www/fusionpbx/core/upgrade/upgrade.php
 ```
 
-**Customize the display name** (Change `<Your Display Name>` to what you want it to be)
+**Customize the display name** (Change `<Your Display Name>` to what you want it to be):
 ```
 sed -i "s/\$apps\[\$x\]\['name'\] = \"Ringotel\";/\$apps\[\$x\]\['name'\] = \"<Your Display Name>\";/" /var/www/fusionpbx/app/<your-folder-name>/app_config.php
 ```

--- a/app_config.php
+++ b/app_config.php
@@ -1,7 +1,7 @@
 <?php 
 
 	//application details
-    $apps[$x]['name'] = ucwords(str_replace(['-', '_'], ' ', basename(__DIR__)));
+    $apps[$x]['name'] = "Ringotel";
     $apps[$x]['uuid'] = "f19f8e69-491b-46d0-9b4f-6599b1756e55";
     $apps[$x]['category'] = "";
     $apps[$x]['subcategory'] = "";

--- a/app_config.php
+++ b/app_config.php
@@ -1,7 +1,7 @@
 <?php 
 
 	//application details
-    $apps[$x]['name'] = "Ringotel";
+    $apps[$x]['name'] = ucwords(str_replace(['-', '_'], ' ', basename(__DIR__)));
     $apps[$x]['uuid'] = "f19f8e69-491b-46d0-9b4f-6599b1756e55";
     $apps[$x]['category'] = "";
     $apps[$x]['subcategory'] = "";

--- a/app_menu.php
+++ b/app_menu.php
@@ -1,6 +1,6 @@
 <?php
 
-$apps[$x]['menu'][0]['title']['en-us'] = "Ringotel";
+$apps[$x]['menu'][0]['title']['en-us'] = ucwords(str_replace(['-', '_'], ' ', basename(dirname(__FILE__))));
 $apps[$x]['menu'][0]['title']['es-cl'] = "";
 $apps[$x]['menu'][0]['title']['es-mx'] = "";
 $apps[$x]['menu'][0]['title']['fr-fr'] = "";
@@ -17,7 +17,7 @@ $apps[$x]['menu'][0]['title']['he'] = "";
 $apps[$x]['menu'][0]['uuid'] = "dfc8340a-188b-4780-9c7a-19294ec55aef";
 $apps[$x]['menu'][0]['parent_uuid'] = "fd29e39c-c936-f5fc-8e2b-611681b266b5";
 $apps[$x]['menu'][0]['category'] = "internal";
-$apps[$x]['menu'][0]['path'] = "/app/ringotel/index.php";
+$apps[$x]['menu'][0]['path'] = "/app/" . basename(dirname(__FILE__)) . "/index.php";
 $apps[$x]['menu'][0]['groups'][] = "superadmin";
 // $apps[$x]['menu'][0]['groups'][] = "admin";
 

--- a/index.php
+++ b/index.php
@@ -2553,7 +2553,7 @@ echo '</style>';
 								<span class="reSyncPassword" style="color: #2196f3;cursor: pointer;padding: 8px;;opacity: 0.75;" alt="Resync Password" data-id="${id}" data-userid="${other?.userid || ''}" data-branch="${branchid}" data-extension="${extension}">
 									<svg fill="#000000" width="15px" height="15px" viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg"><path d="M370.72 133.28C339.458 104.008 298.888 87.962 255.848 88c-77.458.068-144.328 53.178-162.791 126.85-1.344 5.363-6.122 9.15-11.651 9.15H24.103c-7.498 0-13.194-6.807-11.807-14.176C33.933 94.924 134.813 8 256 8c66.448 0 126.791 26.136 171.315 68.685L463.03 40.97C478.149 25.851 504 36.559 504 57.941V192c0 13.255-10.745 24-24 24H345.941c-21.382 0-32.09-25.851-16.971-40.971l41.75-41.749zM32 296h134.059c21.382 0 32.09 25.851 16.971 40.971l-41.75 41.75c31.262 29.273 71.835 45.319 114.876 45.28 77.418-.07 144.315-53.144 162.787-126.849 1.344-5.363 6.122-9.15 11.651-9.15h57.304c7.498 0 13.194 6.807 11.807 14.176C478.067 417.076 377.187 504 256 504c-66.448 0-126.791-26.136-171.315-68.685L48.97 471.03C33.851 486.149 8 475.441 8 454.059V320c0-13.255 10.745-24 24-24z"/></svg>
 								</span>
-								<span class="resetPassword" data-toggle="modal" data-target="#resetPasswordModal" data-id="${id}" data-branch="${branchid}" data-extension="${extension}">
+								<span class="resetPassword" data-toggle="modal" data-target="#resetPasswordModal" data-id="${id}" data-branch="${branchid}" data-extension="${extension}" data-email="${other?.info?.email || other?.email || ''}">
 								  <button type="button" class="btn btn-secondary" data-toggle="tooltip" data-placement="right" title="Reset password" style="
 										margin: 0;
 										padding:  0;
@@ -4095,10 +4095,22 @@ echo '</style>';
 		$(".resetPassword").on('click', (function (el) {
 			const id = el.currentTarget.getAttribute('data-id');
 			const extension = el.currentTarget.getAttribute('data-extension');
+			const email = el.currentTarget.getAttribute('data-email'); // Get the email from data attribute
 			const orgid = $('#delete_organization').attr('data-account') || ORG_ID;
+
+			// Set the attributes
 			$('#email_for_reset_password').attr('data-id', id);
 			$('#email_for_reset_password').attr('data-extension', extension);
 			$('#email_for_reset_password').attr('data-orgid', orgid);
+
+			// AUTO-FILL THE EMAIL
+			if (email && email.trim() !== '') {
+				$('#email_for_reset_password').val(email);
+				$('#reset_user_password_button').attr('disabled', false); // Enable the button since we have an email
+			} else {
+				$('#email_for_reset_password').val('');
+				$('#reset_user_password_button').attr('disabled', true);
+			}
 		}));
 	};
 

--- a/index.php
+++ b/index.php
@@ -4103,7 +4103,7 @@ echo '</style>';
 			$('#email_for_reset_password').attr('data-extension', extension);
 			$('#email_for_reset_password').attr('data-orgid', orgid);
 
-			// AUTO-FILL THE EMAIL
+			// Auto-fill the email
 			if (email && email.trim() !== '') {
 				$('#email_for_reset_password').val(email);
 				$('#reset_user_password_button').attr('disabled', false); // Enable the button since we have an email


### PR DESCRIPTION
- Dynamically determine app name and menu paths from directory name
  instead of hardcoding "Ringotel", making the app portable for
  different provider integrations
  
- Add email pre-population for password reset functionality that
  automatically pulls and fills the current email address from the
  Ringotel portal when resetting user passwords

These changes allow the app to be deployed under any directory name
(e.g., softphone, rt, custom-provider) while maintaining full functionality
and improving the password reset user experience.
