### PR TITLE
ringotel_extension_list.php patch to fix ringotel accounts not loading on extension page

### DIFF
--- a/ringotel_extension_list.php
+++ b/ringotel_extension_list.php
@@ -1,6 +1,12 @@
 
 <?php
-
+// This file is included from app/extensions/extensions.php, which does not
+// run the ringotel app bootstrap, so $application_directory is unset here.
+// Derive it from this file's own location so the service.php URLs resolve
+// in either context (also respects a custom app directory name).
+if (empty($application_directory)) {
+	$application_directory = basename(__DIR__);
+}
 // The Ringotel Checker
 if (!permission_exists("extension_ringotel")) {
     $reject_ringotel = false;


### PR DESCRIPTION
After adding the Ringotel status column to extensions.php, every extension shows a loading spinner that never changes to a status icon.

Cause: ringotel_extension_list.php is being included from extensions.php before $application_directory is set, so the AJAX URL renders as /app//service.php and never reaches Ringotel’s service.php.

Fix: Set or derive $application_directory inside ringotel_extension_list.php so the requests point to /app/ringotel/service.php.